### PR TITLE
Added a list of webhosts that support Cockpit

### DIFF
--- a/getting_started/requirements.md
+++ b/getting_started/requirements.md
@@ -32,7 +32,7 @@ Cockpit was succesfully tested on Apache. Nginx, or whatever web server you choo
 <br>
 #####List of webhosts that supports Cockpit
 * [A Small Orange](http://www.asmallorange.com/)
-* [UnuEuro](http://www.unoeuro.com/)
+* [UnoEuro](http://www.unoeuro.com/)
 * [Meebox](http://www.meebox.net/)
 * [One.com](http://www.one.com)
 * [InMotion Hosting](http://www.inmotionhosting.com/)

--- a/getting_started/requirements.md
+++ b/getting_started/requirements.md
@@ -28,3 +28,15 @@ Cockpit was succesfully tested on Apache. Nginx, or whatever web server you choo
     } catch(Exception $e) {
         echo "Sorry, your server doesn't pass the Cockpit requirements.";
     }
+
+<br>
+#####List of webhosts that supports Cockpit
+* [A Small Orange](http://www.asmallorange.com/)
+* [UnuEuro](http://www.unoeuro.com/)
+* [Meebox](http://www.meebox.net/)
+* [One.com](http://www.one.com)
+* [InMotion Hosting](http://www.inmotionhosting.com/)
+* [Arvixe](http://www.arvixe.com/)
+* [SiteGround](http://www.siteground.com/)
+* [Midphase](https://www.midphase.com/)
+* [Hostway](http://www.hostway.com/)


### PR DESCRIPTION
I've added a list of webhosts that supports Cockpit.

I've talked with all the webhosts technical support, and they assure me that Cockpit works!
The list is MUCH bigger than this, but I don't know more hosts.